### PR TITLE
Updated debian_build.sh for grep parameter and updated configure.ac

### DIFF
--- a/buildutils/debian_build.sh
+++ b/buildutils/debian_build.sh
@@ -88,7 +88,7 @@ func_usage()
 
 get_default_package_class()
 {
-	if dh_make -h 2>/dev/null | grep '\--multi' >/dev/null 2>&1; then
+	if dh_make -h 2>/dev/null | grep -q '\--multi'; then
 		printf 'multi'
 	else
 		printf 'library'

--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,7 @@ AM_INIT_AUTOMAKE()
 #
 # Checks for programs.
 #
+AC_PROG_CXX
 AC_PROG_AWK
 AC_PROG_CC
 AC_PROG_INSTALL


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Fixed the part where the `grep` command parameter was not appropriate.
And added macros to `configure.ac` because they were missing.