### PR TITLE
Changed support OS (fedora and ubuntu) and updated tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,15 +57,14 @@ jobs:
         container:
           - ubuntu:22.04
           - ubuntu:20.04
-          - ubuntu:18.04
           - debian:bookworm
           - debian:bullseye
           - debian:buster
           - rockylinux:9
           - rockylinux:8
           - centos:centos7
+          - fedora:38
           - fedora:37
-          - fedora:36
           - alpine:3.18
 
     container:

--- a/.github/workflows/ostypevars.sh
+++ b/.github/workflows/ostypevars.sh
@@ -116,20 +116,6 @@ elif [ "${CI_OSTYPE}" = "ubuntu:20.04" ] || [ "${CI_OSTYPE}" = "ubuntu:focal" ];
 	PKG_EXT="deb"
 	IS_OS_UBUNTU=1
 
-elif [ "${CI_OSTYPE}" = "ubuntu:18.04" ] || [ "${CI_OSTYPE}" = "ubuntu:bionic" ]; then
-	DIST_TAG="ubuntu/bionic"
-	INSTALL_PKG_LIST="git autoconf autotools-dev make dh-make fakeroot dpkg-dev devscripts pkg-config ruby-dev rubygems rubygems-integration procps dh-systemd"
-	INSTALLER_BIN="apt-get"
-	UPDATE_CMD="update"
-	UPDATE_CMD_ARG=""
-	INSTALL_CMD="install"
-	INSTALL_CMD_ARG=""
-	INSTALL_AUTO_ARG="-y"
-	INSTALL_QUIET_ARG="-qq"
-	PKG_OUTPUT_DIR="debian_build"
-	PKG_EXT="deb"
-	IS_OS_UBUNTU=1
-
 elif [ "${CI_OSTYPE}" = "debian:12" ] || [ "${CI_OSTYPE}" = "debian:bookworm" ]; then
 	DIST_TAG="debian/bookworm"
 	INSTALL_PKG_LIST="git autoconf autotools-dev make dh-make fakeroot dpkg-dev devscripts pkg-config ruby-dev rubygems rubygems-integration procps"
@@ -214,8 +200,8 @@ elif [ "${CI_OSTYPE}" = "centos:7" ] || [ "${CI_OSTYPE}" = "centos:centos7" ]; t
 	PKG_EXT="rpm"
 	IS_OS_CENTOS=1
 
-elif [ "${CI_OSTYPE}" = "fedora:37" ]; then
-	DIST_TAG="fedora/37"
+elif [ "${CI_OSTYPE}" = "fedora:38" ]; then
+	DIST_TAG="fedora/38"
 	INSTALL_PKG_LIST="git autoconf automake gcc-c++ make pkgconfig redhat-rpm-config rpm-build ruby-devel rubygems procps systemd"
 	INSTALLER_BIN="dnf"
 	UPDATE_CMD="update"
@@ -228,8 +214,8 @@ elif [ "${CI_OSTYPE}" = "fedora:37" ]; then
 	PKG_EXT="rpm"
 	IS_OS_FEDORA=1
 
-elif [ "${CI_OSTYPE}" = "fedora:36" ]; then
-	DIST_TAG="fedora/36"
+elif [ "${CI_OSTYPE}" = "fedora:37" ]; then
+	DIST_TAG="fedora/37"
 	INSTALL_PKG_LIST="git autoconf automake gcc-c++ make pkgconfig redhat-rpm-config rpm-build ruby-devel rubygems procps systemd"
 	INSTALLER_BIN="dnf"
 	UPDATE_CMD="update"


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
- Supported OS has been changed.  
Does not support fedora 36  
Added support for fedora 38  
Does not support Ubuntu 18.04  

- Fixed `build_helper.sh`  
The minimum Ruby version required for the `package_cloud` command has been changed to 2.6, and `build_helper.sh` has been modified accordingly.