### PR TITLE
Fixed APKBUILD.templ.in for alpine v3.23

### DIFF
--- a/buildutils/APKBUILD.templ.in
+++ b/buildutils/APKBUILD.templ.in
@@ -92,8 +92,8 @@ unpack() {
 	# In this case, change the directory name to the package name
 	# (k2hr3-get-resource) instead of the repository name.
 	#
-	if [ -d "$_repository_name-$pkgver" ]; then
-		mv "$_repository_name-$pkgver" "$pkgname-$pkgver"
+	if [ -d "$srcdir/$_repository_name-$pkgver" ]; then
+		mv "$srcdir/$_repository_name-$pkgver" "$srcdir/$pkgname-$pkgver"
 	fi
 }
 


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
In ALPINE v3.23, there was an issue with script code of `APKBUILD.templ.in`, causing package creation to fail.
This has been fixed.